### PR TITLE
Alter for k8s production

### DIFF
--- a/autoreduce_frontend/autoreduce_webapp/settings.py
+++ b/autoreduce_frontend/autoreduce_webapp/settings.py
@@ -127,7 +127,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 if not DEBUG:
-    STATIC_ROOT = '/staticfiles'
+    STATIC_ROOT = '/var/www/api'
 else:
     STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 

--- a/autoreduce_frontend/autoreduce_webapp/settings.py
+++ b/autoreduce_frontend/autoreduce_webapp/settings.py
@@ -135,16 +135,6 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]
 
-# ActiveMQ
-
-ACTIVEMQ = {
-    'topics': ['/queue/DataReady'],
-    'username': os.getenv('ACTIVEMQ_USERNAME'),
-    'password': os.getenv('ACTIVEMQ_PASSWORD'),
-    'broker': [os.getenv('ACTIVEMQ_HOST'), os.getenv('ACTIVEMQ_PORT')],
-    'SSL': False
-}
-
 # ICAT
 ICAT = {
     'AUTH': os.getenv('ICAT_AUTH'),

--- a/autoreduce_frontend/selenium_tests/utils.py
+++ b/autoreduce_frontend/selenium_tests/utils.py
@@ -105,8 +105,8 @@ def setup_external_services(instrument_name: str, start_year: int,
     try:
         publisher, consumer = setup_kafka_connections()
     except ConnectionException as err:
-        raise RuntimeError("Could not connect to ActiveMQ - check your credentials. If running locally check that "
-                           "the ActiveMQ Docker container is running") from err
+        raise RuntimeError("Could not connect to Kafka - check your broker. If running locally check that "
+                           "the Kafka Docker container is running") from err
 
     return data_archive, publisher, consumer
 


### PR DESCRIPTION
### Summary of work
Removes fetching environ vars for ACTIVE_MQ 
Switches STATIC_ROOT from '/staticfiles' to '/var/www/api' if NOT DEBUG